### PR TITLE
Closes: #8

### DIFF
--- a/mercuryorm/base.py
+++ b/mercuryorm/base.py
@@ -61,16 +61,11 @@ class CustomObject:
 
         return False
 
-    def save(self):
+    def format_record(self):
         """
-        Saves the record in Zendesk (creates or updates).
-
-        Raises:
-            CreateRecordError: If the record could not be created.
-            UpdateRecordError: If the record could not be updated.
-            UniqueConstraintError: If a unique constraint is violated.
+        Formats the current object to be sent to the API.
         """
-        data = {
+        return {
             "custom_object_record": {
                 "custom_object_fields": self.to_save(),
                 "name": (
@@ -81,6 +76,17 @@ class CustomObject:
                 "external_id": getattr(self, "external_id", None),
             }
         }
+
+    def save(self):
+        """
+        Saves the record in Zendesk (creates or updates).
+
+        Raises:
+            CreateRecordError: If the record could not be created.
+            UpdateRecordError: If the record could not be updated.
+            UniqueConstraintError: If a unique constraint is violated.
+        """
+        data = self.format_record()
         # -> If object not contains a NameField type
         # the name field is Unnamed Object or a name passed
 

--- a/mercuryorm/exceptions.py
+++ b/mercuryorm/exceptions.py
@@ -157,3 +157,11 @@ class CustomObjectFieldCreationError(Exception):
     def __init__(self, message: str | dict):
         self.message = message
         super().__init__(self.message)
+
+
+class BulkRecordsError(Exception):
+    """An exception for all bulk records errors."""
+
+    def __init__(self, message: str | dict):
+        self.message = message
+        super().__init__(self.message)

--- a/mercuryorm/fields.py
+++ b/mercuryorm/fields.py
@@ -349,10 +349,10 @@ class DecimalField(Field):  # pylint: disable=too-few-public-methods
         """
         super().__init__(name, FieldTypes.DECIMAL, float)
 
-    def __set__(self, instance: object, value: float | None) -> None:
-        super().__set__(instance, value)
+    def __set__(self, instance: object, value: float | int | None) -> None:
+        super().__set__(instance, float(value) if value is not None else None)
 
-    def __get__(self, instance: object, owner: type) -> float | None:
+    def __get__(self, instance: object, owner: type) -> float | int | None:
         value = super().__get__(instance, owner)
         return value
 


### PR DESCRIPTION
## Feat: Add bulk operations #8
- Add all zendesk bulk operations:
  - Create
  - Update
  - Delete
  - Delete by external_id
  - Create or Update by external_id
  - Create or Update by name

For Example:
We use `Teste.objects.bulk.create(testes)`

Closes #8 