### PR TITLE
Resolves: #37, #36 , #32

### DIFF
--- a/mercuryorm/base.py
+++ b/mercuryorm/base.py
@@ -133,6 +133,15 @@ class CustomObject:
 
         return response
 
+    def to_save(self):
+        """
+        Converts the current object to a dictionary format for saving in Zendesk.
+
+        Returns:
+            dict: A dictionary containing the object's fields and values.
+        """
+        return self._format_fields(to_save=True)
+
     def to_dict(self):
         """
         Converts the current object to a dictionary format, including custom fields and
@@ -141,20 +150,21 @@ class CustomObject:
         Returns:
             dict: A dictionary containing the object's fields and values.
         """
-        return self._format_fields(to_representation=True)
-
-    def to_save(self):
-        """
-        Converts the current object to a dictionary format for saving in Zendesk,
-        including custom fields and default fields required by the API.
-
-        Returns:
-            dict: A dictionary containing the object's
-            fields and values to save on Zendesk.
-        """
         return self._format_fields()
 
-    def _format_fields(self, to_representation: bool = False) -> dict:
+    def to_representation(self):
+        """
+        Converts the current object to a dictionary format for representation, using labels.
+
+        Returns:
+            dict: A dictionary containing the object's fields and values.
+            in choice fields return {value: value, label: label}
+        """
+        return self._format_fields(to_representation=True)
+
+    def _format_fields(
+        self, to_representation: bool = False, to_save: bool = False
+    ) -> dict:
         """
         Formats the fields of the object to be sent to the API.
 
@@ -189,7 +199,7 @@ class CustomObject:
                         )
                 elif (
                     isinstance(field, fields.AttachmentField)
-                    and not to_representation
+                    and to_save
                     and getattr(self, field_name) is not None
                 ):
                     field_instance = getattr(self, field_name)

--- a/mercuryorm/fields.py
+++ b/mercuryorm/fields.py
@@ -470,8 +470,8 @@ class DropdownField(Field):  # pylint: disable=too-few-public-methods
         if value is None:
             return None
         if self.to_representation:
-            value = self.to_representation[value]
-        return value
+            return {"value": value, "label": self.to_representation[value]}
+        return {"value": value, "label": value}
 
     def __get__(self, instance: object, owner: type) -> str | None:
         return super().__get__(instance, owner)
@@ -599,8 +599,10 @@ class MultiselectField(Field):  # pylint: disable=too-few-public-methods
         if value is None:
             return None
         if self.to_representation:
-            value = [self.to_representation[item] for item in value]
-        return value
+            return [
+                {"value": item, "label": self.to_representation[item]} for item in value
+            ]
+        return [{"value": item, "label": item} for item in value]
 
     def __get__(self, instance: object, owner: type) -> List[str] | None:
         return super().__get__(instance, owner)
@@ -642,16 +644,4 @@ class AttachmentField(Field):
         return super().__get__(instance, owner)
 
     def __set__(self, instance: object, value: AttachmentFile | None) -> None:
-        """
-        Set the value of the attachment field.
-
-        Args:
-            instance: The instance of the class.
-            value: The value to set for the attachment field.
-
-        Raises:
-            ValueError: If the value is not an instance of AttachmentFile.
-        """
-        if not self.validate(value):
-            raise FieldTypeError(self.name, self.data_type)
-        instance.__dict__[self.name] = value
+        super().__set__(instance, value)

--- a/mercuryorm/file.py
+++ b/mercuryorm/file.py
@@ -110,7 +110,7 @@ class AttachmentFile:
         """
         Attachment ID.
         """
-        if not getattr(self, "zendesk_data"):
+        if not self.zendesk_data:
             return self._id
         return self.zendesk_data["id"]
 
@@ -141,10 +141,10 @@ class AttachmentFile:
         """
         if not self._id:
             return None
-        if not getattr(self, "zendesk_data"):
+        if not self.zendesk_data:
             self.zendesk_data = self._get_attachment_details(self._id)
             self.saved = True
-        if self.saved and getattr(self, "zendesk_data"):
+        if self.saved and self.zendesk_data:
             return self.zendesk_data[key]
         raise ValueError("File not saved yet, to save use save() method.")
 

--- a/mercuryorm/managers.py
+++ b/mercuryorm/managers.py
@@ -42,14 +42,6 @@ class QuerySet:
         """
         Returns the 100 first records from the Custom Object without metadata or links.
         """
-        response = self.client.get(self.base_url)
-        records = self._parse_response(response)
-        return records
-
-    def all_of(self):
-        """
-        Returns all records from the Custom Object, handling pagination automatically.
-        """
         records = []
         next_cursor = None
 


### PR DESCRIPTION
## - Fixed error cases when creating attachmentField when it is null

  - Now, __set__ and __get__ save values in the class instance
  - Now, in _format_fields, AttachmentFile.save() is only used under the correct conditions (this was causing the errors)
  - Now, the data is only fetched if one of the properties is accessed.

## - Fixed the all method of CustomObject, which now retrieves all records literally

## - Fixed MultiSelect and Dropdown to return representation values only in to_dict()

## - Now, to_dict() serializes the attachment as a dictionary in the following format: 

```json
{
"id": "string",
"filename": "string",
"url": "string",
"size": "string"
}
```

Resolves: #37 
Resolves: #36 
Resolves: #32 