### PR TITLE
Adjust format_records to skip returning name when NameField type is autoincrement

### DIFF
--- a/mercuryorm/base.py
+++ b/mercuryorm/base.py
@@ -70,18 +70,17 @@ class CustomObject:
         """
         Formats the current object to be sent to the API.
         """
-        return {
+        data = {
             "custom_object_record": {
                 "custom_object_fields": self.to_save(),
-                "name": (
-                    getattr(self, "name") or "Unnamed Object"
-                    if not self.is_namefield_autoincrement()
-                    else None
-                ),
                 "id": getattr(self, "id", None),
                 "external_id": getattr(self, "external_id", None),
             }
         }
+        if not self.is_namefield_autoincrement():
+            data["custom_object_record"]["name"] = getattr(self, "name", None)
+
+        return data
 
     def save(self):
         """


### PR DESCRIPTION
## fix(base): adjust format_records to skip returning name when NameField type is autoincrement

fixes error during bulk update when attempting to update with autoincrement NameField