### PR TITLE
Set default name to "Unnamed Object" in format_record

### DIFF
--- a/mercuryorm/base.py
+++ b/mercuryorm/base.py
@@ -78,7 +78,9 @@ class CustomObject:
             }
         }
         if not self.is_namefield_autoincrement():
-            data["custom_object_record"]["name"] = getattr(self, "name", None)
+            data["custom_object_record"]["name"] = (
+                getattr(self, "name", None) or "Unnamed Object"
+            )
 
         return data
 


### PR DESCRIPTION
fix: set default name to "Unnamed Object" in format_record if NameField is autoincrement